### PR TITLE
Fix catalog reactivity

### DIFF
--- a/src/lib/components/ModelSelect.tsx
+++ b/src/lib/components/ModelSelect.tsx
@@ -32,10 +32,18 @@ export function ModelSelect({
   const effectiveSelectedRole = context?.state.selectedRole ?? selectedRole;
   const effectiveOnRoleChange = context?.selectRole ?? onRoleChange;
   const [showAddModelForm, setShowAddModelForm] = useState(false);
-  const hookOptions: { telemetry?: import('../types').ModelPickerTelemetry; modelStorage?: import('../types').StorageAdapter; prefetch?: boolean } = {};
+  const hookOptions: {
+    telemetry?: import('../types').ModelPickerTelemetry;
+    modelStorage?: import('../types').StorageAdapter;
+    prefetch?: boolean;
+    catalog?: import('../catalog/ModelCatalog').ModelCatalog;
+    manageStorage?: boolean;
+  } = {};
   if (effectiveTelemetry !== undefined) hookOptions.telemetry = effectiveTelemetry;
   if (effectiveModelStorage !== undefined) hookOptions.modelStorage = effectiveModelStorage;
   hookOptions.prefetch = true;
+  if (context?.catalog !== undefined) hookOptions.catalog = context.catalog;
+  if (context !== undefined) hookOptions.manageStorage = false;
   const {
     recentlyUsedModels,
     modelsWithCredentials,

--- a/src/lib/context/index.ts
+++ b/src/lib/context/index.ts
@@ -17,9 +17,11 @@ import type {
   ThemeConfig,
   ProviderId,
 } from '../types';
+import { providerAndModelKey } from '../types';
 import type { ModelPickerTelemetry } from '../types';
 import { ModelCatalog } from '../catalog/ModelCatalog';
 import { setGlobalTelemetry } from '../telemetry';
+import { addProviderWithCredentials, addRecentlyUsedModel } from '../storage/repository';
 
 // State interface
 interface ModelPickerState {
@@ -165,9 +167,16 @@ export function ModelPickerProvider({
   }, [state.selectedModelId, allModels]);
 
   // Action creators
-  const selectModel = useCallback((model: ModelConfigWithProvider | undefined) => {
-    dispatch({ type: 'SET_MODEL', payload: model?.model.id });
-  }, []);
+  const selectModel = useCallback(
+    (model: ModelConfigWithProvider | undefined) => {
+      dispatch({ type: 'SET_MODEL', payload: model?.model.id });
+      if (model !== undefined) {
+        void addProviderWithCredentials(storage, model.provider.id);
+        void addRecentlyUsedModel(storage, providerAndModelKey(model));
+      }
+    },
+    [storage]
+  );
 
   const selectRole = useCallback((roleId: string) => {
     dispatch({ type: 'SET_ROLE', payload: roleId });

--- a/src/lib/context/index.ts
+++ b/src/lib/context/index.ts
@@ -4,6 +4,7 @@ import {
   useReducer,
   useMemo,
   useCallback,
+  useSyncExternalStore,
   type ReactNode,
   createElement,
 } from 'react';
@@ -137,9 +138,14 @@ export function ModelPickerProvider({
     return undefined;
   }, [catalog, prefetch, telemetry]);
 
-  // All models flattened from catalog snapshot (filter visible)
+  // Subscribe to catalog updates and flatten visible models
+  const snapshot = useSyncExternalStore(
+    useCallback((onStoreChange: () => void) => catalog.subscribe(onStoreChange), [catalog]),
+    useCallback(() => catalog.getSnapshot(), [catalog]),
+    useCallback(() => catalog.getSnapshot(), [catalog])
+  );
+
   const allModels = useMemo(() => {
-    const snapshot = catalog.getSnapshot();
     const arr: ModelConfigWithProvider[] = [];
     for (const entry of Object.values(snapshot)) {
       for (const mp of entry.models) {
@@ -148,7 +154,7 @@ export function ModelPickerProvider({
       }
     }
     return arr;
-  }, [catalog]);
+  }, [snapshot]);
 
   // Find selected model
   const selectedModel = useMemo(() => {

--- a/src/lib/providers/ProviderRegistry.ts
+++ b/src/lib/providers/ProviderRegistry.ts
@@ -94,20 +94,6 @@ export class ProviderRegistry implements IProviderRegistry {
   }
 
   /**
-   * Get all models for a specific provider
-   * @param providerId The provider ID
-   * @returns Array of models for the provider
-   */
-  getModelsForProvider(providerId: ProviderId): ModelConfigWithProvider[] {
-    const provider = this.getProvider(providerId);
-
-    return provider.models.map((model) => ({
-      model,
-      provider: provider.metadata,
-    }));
-  }
-
-  /**
    * Find providers that support a specific capability
    * @param capability The capability to search for (e.g., vision, tools)
    * @returns Array of providers supporting the capability
@@ -115,12 +101,6 @@ export class ProviderRegistry implements IProviderRegistry {
   getProvidersByCapability(capability: keyof ModelConfigWithProvider['model']): AIProvider[] {
     return this.getAllProviders().filter((provider) =>
       provider.models.some((model) => model[capability] === true)
-    );
-  }
-
-  getAllModels(): ModelConfigWithProvider[] {
-    return this.getAllProviders().flatMap((provider) =>
-      provider.models.map((model) => ({ model, provider: provider.metadata }))
     );
   }
 }

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -216,8 +216,6 @@ export interface IProviderRegistry {
   register(provider: AIProvider): ProviderId;
   getProvider(providerId: ProviderId): AIProvider;
   getAllProviders(): AIProvider[];
-  getAllModels(): ModelConfigWithProvider[];
-  getModelsForProvider(providerId: ProviderId): ModelConfigWithProvider[];
   getProviderMetadata(providerId: ProviderId): ProviderMetadata;
   hasProvider(providerId: ProviderId): boolean;
 }


### PR DESCRIPTION
## Summary by Sourcery

Enhance catalog reactivity and state management in the model picker hook by subscribing to catalog updates, supporting external catalog injection, and introducing a manageStorage option to control persistence, while cleaning up unused registry methods and improving offline model loading.

New Features:
- Introduce manageStorage option in useModelsWithConfiguredProvider to control persistence writes
- Allow injecting an external ModelCatalog into the model picker hook

Bug Fixes:
- Fix stale UI by subscribing to ModelCatalog changes with useSyncExternalStore
- Prevent double-writing provider credentials in ModelSelect by honoring the manageStorage flag

Enhancements:
- Derive available models dynamically from catalog snapshots and simplify hook state by tracking provider IDs
- Distinguish internal vs external catalog instances for controlled initialization
- Load persisted models for all providers in ModelCatalog to preserve offline state
- Remove obsolete methods from ProviderRegistry to streamline the API
- Add telemetry error handling around storage writes to avoid UI crashes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Real-time model list updates that reflect catalog changes instantly.
  - Offline view now shows known models from all providers.
  - Automatically records recently used models when a selection is made.

- Improvements
  - More precise refresh limited to providers with credentials.
  - Flexible catalog ownership and storage management in model selection flows.

- Bug Fixes
  - Prevented UI crashes on storage write failures with graceful handling and telemetry reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->