### PR TITLE
[codex] Address PR 48 review comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, develop]
@@ -50,9 +53,7 @@ jobs:
         run: pnpm audit --audit-level=moderate
 
       - name: Validate packaging
-        run: |
-          pnpm exec publint --strict
-          pnpm exec attw --pack . --exclude-entrypoints styles.css
+        run: pnpm run validate:packaging
 
   compatibility:
     name: Check AI SDK Compatibility

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,9 +55,7 @@ jobs:
         run: pnpm run build
 
       - name: Validate packaging
-        run: |
-          pnpm exec publint --strict
-          pnpm exec attw --pack . --exclude-entrypoints styles.css
+        run: pnpm run validate:packaging
 
       - name: Check package contents
         run: pnpm pack

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Install the AI SDK providers you plan to use:
 
 ```bash
 # Core (always needed, React 19 is required)
-npm install react react-dom react-hook-form
+npm install react@^19 react-dom@^19 react-hook-form
 
 # AI SDK providers (install as needed)
 npm install @ai-sdk/openai @ai-sdk/anthropic @ai-sdk/google
@@ -224,7 +224,7 @@ See guides for type-accurate props and APIs:
 Manages all available providers.
 
 ```tsx
-import { ProviderRegistry } from 'ai-sdk-react-model-picker';
+import { AnthropicProvider, OpenAIProvider, ProviderRegistry } from 'ai-sdk-react-model-picker';
 
 const registry = new ProviderRegistry();
 

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -12,7 +12,7 @@ Peer deps you’ll likely need:
 
 ```bash
 # React 19 is required
-npm install react react-dom react-hook-form
+npm install react@^19 react-dom@^19 react-hook-form
 # Add only the AI SDK providers you use
 npm install @ai-sdk/openai @ai-sdk/anthropic @ai-sdk/google
 npm install @ai-sdk/azure @ai-sdk/mistral @ai-sdk/cohere @ai-sdk/amazon-bedrock

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "lint": "eslint .",
     "lint:fix": "tsc --noEmit && eslint . --fix",
     "typecheck": "tsc --noEmit",
+    "validate:packaging": "publint --strict && attw --pack . --exclude-entrypoints styles.css",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "test": "vitest --run",

--- a/tailwind-preset.cjs
+++ b/tailwind-preset.cjs
@@ -93,22 +93,21 @@ module.exports = {
       borderRadius: {
         DEFAULT: 'var(--mp-border-radius, 0.375rem)',
       },
-      
+
       fontSize: {
-        'xs': ['0.75rem', { lineHeight: '1rem' }],
-        'sm': ['0.875rem', { lineHeight: '1.25rem' }],
-        'base': ['1rem', { lineHeight: '1.5rem' }],
-        'lg': ['1.125rem', { lineHeight: '1.75rem' }],
+        xs: ['0.75rem', { lineHeight: '1rem' }],
+        sm: ['0.875rem', { lineHeight: '1.25rem' }],
+        base: ['1rem', { lineHeight: '1.5rem' }],
+        lg: ['1.125rem', { lineHeight: '1.75rem' }],
       },
-      
+
       spacing: {
-        '18': '4.5rem',
+        18: '4.5rem',
       },
-      
+
       animation: {
         'spin-slow': 'spin 2s linear infinite',
       },
-      
     },
   },
   plugins: [
@@ -123,38 +122,152 @@ module.exports = {
         }
       };
 
-      const hexToRgb = (hex) => {
-        if (typeof hex !== 'string') return undefined;
-        let h = hex.trim();
-        if (h.startsWith('rgb(')) {
-          const m = h.match(/rgba?\(([^)]+)\)/);
-          if (m) {
-            const parts = m[1].split(/[\s,\/]+/).filter(Boolean);
-            const [r, g, b] = parts.map((n) => parseInt(n, 10));
-            if (Number.isFinite(r) && Number.isFinite(g) && Number.isFinite(b)) {
-              return `${r} ${g} ${b}`;
-            }
-          }
+      const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+      const formatRgb = (r, g, b) =>
+        `${Math.round(clamp(r, 0, 255))} ${Math.round(clamp(g, 0, 255))} ${Math.round(clamp(b, 0, 255))}`;
+      const splitChannels = (value) =>
+        value
+          .trim()
+          .split(/[,\s/]+/)
+          .filter(Boolean);
+      const parseNumber = (value) => {
+        const number = Number.parseFloat(value);
+        return Number.isFinite(number) ? number : undefined;
+      };
+      const parsePercentage = (value) => {
+        const number = parseNumber(value);
+        if (number === undefined) return undefined;
+        return clamp(
+          value.trim().endsWith('%') ? number / 100 : number > 1 ? number / 100 : number,
+          0,
+          1
+        );
+      };
+      const parseHue = (value) => {
+        const trimmed = value.trim();
+        const number = parseNumber(trimmed);
+        if (number === undefined) return undefined;
+        if (trimmed.endsWith('turn')) return number * 360;
+        if (trimmed.endsWith('rad')) return number * (180 / Math.PI);
+        if (trimmed.endsWith('grad')) return number * 0.9;
+        return number;
+      };
+      const parseRgbChannel = (value) => {
+        const number = parseNumber(value);
+        if (number === undefined) return undefined;
+        return value.trim().endsWith('%')
+          ? clamp((number / 100) * 255, 0, 255)
+          : clamp(number, 0, 255);
+      };
+      const parseFunction = (value, name) => {
+        const match = value.match(new RegExp(`^${name}a?\\((.*)\\)$`, 'i'));
+        return match ? splitChannels(match[1]) : undefined;
+      };
+      const parseHexColor = (value) => {
+        if (!value.startsWith('#')) return undefined;
+        let hex = value.slice(1);
+        if (!/^[\da-f]+$/i.test(hex)) return undefined;
+        if (hex.length === 3 || hex.length === 4) {
+          hex = hex
+            .slice(0, 3)
+            .split('')
+            .map((c) => c + c)
+            .join('');
+        } else if (hex.length === 8) {
+          hex = hex.slice(0, 6);
+        } else if (hex.length !== 6) {
           return undefined;
         }
-        if (!h.startsWith('#')) return undefined;
-        h = h.slice(1);
-        if (h.length === 3) {
-          h = h.split('').map((c) => c + c).join('');
-          } else if (h.length === 4) { // #RGBA
-            h = h.split('').map((c, i) => (i < 3 ? c + c : '')).join('');
-          } else if (h.length === 8) { // #RRGGBBAA
-            h = h.slice(0, 6);
-          }
-        const num = parseInt(h, 16);
+        const num = Number.parseInt(hex, 16);
         if (!Number.isFinite(num)) return undefined;
-        const r = (num >> 16) & 255;
-        const g = (num >> 8) & 255;
-        const b = num & 255;
-        return `${r} ${g} ${b}`;
+        return formatRgb((num >> 16) & 255, (num >> 8) & 255, num & 255);
+      };
+      const parseRgbColor = (value) => {
+        const parts = parseFunction(value, 'rgb');
+        if (!parts || parts.length < 3) return undefined;
+        const channels = parts.slice(0, 3).map(parseRgbChannel);
+        if (channels.some((channel) => channel === undefined)) return undefined;
+        return formatRgb(channels[0], channels[1], channels[2]);
+      };
+      const parseHslColor = (value) => {
+        const parts = parseFunction(value, 'hsl');
+        if (!parts || parts.length < 3) return undefined;
+        const hue = parseHue(parts[0]);
+        const saturation = parsePercentage(parts[1]);
+        const lightness = parsePercentage(parts[2]);
+        if (hue === undefined || saturation === undefined || lightness === undefined)
+          return undefined;
+
+        const normalizedHue = (((hue % 360) + 360) % 360) / 360;
+        if (saturation === 0) {
+          const gray = lightness * 255;
+          return formatRgb(gray, gray, gray);
+        }
+
+        const q =
+          lightness < 0.5
+            ? lightness * (1 + saturation)
+            : lightness + saturation - lightness * saturation;
+        const p = 2 * lightness - q;
+        const hueToRgb = (t) => {
+          let channel = t;
+          if (channel < 0) channel += 1;
+          if (channel > 1) channel -= 1;
+          if (channel < 1 / 6) return p + (q - p) * 6 * channel;
+          if (channel < 1 / 2) return q;
+          if (channel < 2 / 3) return p + (q - p) * (2 / 3 - channel) * 6;
+          return p;
+        };
+
+        return formatRgb(
+          hueToRgb(normalizedHue + 1 / 3) * 255,
+          hueToRgb(normalizedHue) * 255,
+          hueToRgb(normalizedHue - 1 / 3) * 255
+        );
+      };
+      const parseOklchColor = (value) => {
+        const match = value.match(/^oklch\((.*)\)$/i);
+        if (!match) return undefined;
+        const parts = splitChannels(match[1]);
+        if (parts.length < 3) return undefined;
+
+        const lightness = parsePercentage(parts[0]);
+        const chromaNumber = parseNumber(parts[1]);
+        const hue = parseHue(parts[2]);
+        if (lightness === undefined || chromaNumber === undefined || hue === undefined)
+          return undefined;
+
+        const chroma = parts[1].trim().endsWith('%') ? (chromaNumber / 100) * 0.4 : chromaNumber;
+        const hueRadians = (hue * Math.PI) / 180;
+        const a = chroma * Math.cos(hueRadians);
+        const b = chroma * Math.sin(hueRadians);
+        const lPrime = lightness + 0.3963377774 * a + 0.2158037573 * b;
+        const mPrime = lightness - 0.1055613458 * a - 0.0638541728 * b;
+        const sPrime = lightness - 0.0894841775 * a - 1.291485548 * b;
+        const l = lPrime ** 3;
+        const m = mPrime ** 3;
+        const s = sPrime ** 3;
+        const toSrgb = (channel) =>
+          channel <= 0.0031308 ? 12.92 * channel : 1.055 * channel ** (1 / 2.4) - 0.055;
+
+        return formatRgb(
+          toSrgb(4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s) * 255,
+          toSrgb(-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s) * 255,
+          toSrgb(-0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s) * 255
+        );
+      };
+      const colorToRgb = (color) => {
+        if (typeof color !== 'string') return undefined;
+        const value = color.trim();
+        return (
+          parseRgbColor(value) ||
+          parseHexColor(value) ||
+          parseHslColor(value) ||
+          parseOklchColor(value)
+        );
       };
 
-      const toRgb = (val, fallbackHex) => hexToRgb(val) || hexToRgb(fallbackHex);
+      const toRgb = (val, fallbackHex) => colorToRgb(val) || colorToRgb(fallbackHex);
 
       const fallbacks = {
         white: '#ffffff',
@@ -178,84 +291,233 @@ module.exports = {
       };
 
       const primary = toRgb(resolve('colors.primary.500', fallbacks.blue500), fallbacks.blue500);
-      const primaryHover = toRgb(resolve('colors.primary.600', fallbacks.blue600), fallbacks.blue600);
+      const primaryHover = toRgb(
+        resolve('colors.primary.600', fallbacks.blue600),
+        fallbacks.blue600
+      );
 
-      const destructive = toRgb(resolve('colors.destructive.DEFAULT', fallbacks.red500), fallbacks.red500) || toRgb(fallbacks.red500, fallbacks.red500);
-      const destructiveHover = toRgb(resolve('colors.destructive.hover', fallbacks.red600), fallbacks.red600) || toRgb(fallbacks.red600, fallbacks.red600);
-      const success = toRgb(resolve('colors.success.DEFAULT', fallbacks.green500), fallbacks.green500) || toRgb(fallbacks.green500, fallbacks.green500);
-      const successHover = toRgb(resolve('colors.success.hover', fallbacks.green600), fallbacks.green600) || toRgb(fallbacks.green600, fallbacks.green600);
-      const warning = toRgb(resolve('colors.warning.DEFAULT', fallbacks.amber500), fallbacks.amber500) || toRgb(fallbacks.amber500, fallbacks.amber500);
-      const warningHover = toRgb(resolve('colors.warning.hover', fallbacks.amber600), fallbacks.amber600) || toRgb(fallbacks.amber600, fallbacks.amber600);
+      const destructive =
+        toRgb(resolve('colors.destructive.DEFAULT', fallbacks.red500), fallbacks.red500) ||
+        toRgb(fallbacks.red500, fallbacks.red500);
+      const destructiveHover =
+        toRgb(resolve('colors.destructive.hover', fallbacks.red600), fallbacks.red600) ||
+        toRgb(fallbacks.red600, fallbacks.red600);
+      const success =
+        toRgb(resolve('colors.success.DEFAULT', fallbacks.green500), fallbacks.green500) ||
+        toRgb(fallbacks.green500, fallbacks.green500);
+      const successHover =
+        toRgb(resolve('colors.success.hover', fallbacks.green600), fallbacks.green600) ||
+        toRgb(fallbacks.green600, fallbacks.green600);
+      const warning =
+        toRgb(resolve('colors.warning.DEFAULT', fallbacks.amber500), fallbacks.amber500) ||
+        toRgb(fallbacks.amber500, fallbacks.amber500);
+      const warningHover =
+        toRgb(resolve('colors.warning.hover', fallbacks.amber600), fallbacks.amber600) ||
+        toRgb(fallbacks.amber600, fallbacks.amber600);
 
       addBase({
         ':root': {
           // Core semantic tokens (RGB triplets)
-          '--mp-background-rgb': toRgb(resolve('colors.background.DEFAULT', fallbacks.white), fallbacks.white),
-          '--mp-background-secondary-rgb': toRgb(resolve('colors.background.secondary', fallbacks.gray100), fallbacks.gray100),
-          '--mp-foreground-rgb': toRgb(resolve('colors.foreground.DEFAULT', fallbacks.gray900), fallbacks.gray900),
-          '--mp-foreground-secondary-rgb': toRgb(resolve('colors.foreground.secondary', fallbacks.gray700), fallbacks.gray700),
+          '--mp-background-rgb': toRgb(
+            resolve('colors.background.DEFAULT', fallbacks.white),
+            fallbacks.white
+          ),
+          '--mp-background-secondary-rgb': toRgb(
+            resolve('colors.background.secondary', fallbacks.gray100),
+            fallbacks.gray100
+          ),
+          '--mp-foreground-rgb': toRgb(
+            resolve('colors.foreground.DEFAULT', fallbacks.gray900),
+            fallbacks.gray900
+          ),
+          '--mp-foreground-secondary-rgb': toRgb(
+            resolve('colors.foreground.secondary', fallbacks.gray700),
+            fallbacks.gray700
+          ),
           '--mp-primary-rgb': primary,
           '--mp-primary-hover-rgb': primaryHover,
-          '--mp-primary-foreground-rgb': toRgb(resolve('colors.primary.foreground', fallbacks.white), fallbacks.white),
-          '--mp-border-rgb': toRgb(resolve('colors.border.DEFAULT', fallbacks.gray200), fallbacks.gray200),
-          '--mp-border-muted-rgb': toRgb(resolve('colors.border.muted', fallbacks.gray300), fallbacks.gray300),
-          '--mp-muted-rgb': toRgb(resolve('colors.foreground.muted', fallbacks.gray700), fallbacks.gray700),
+          '--mp-primary-foreground-rgb': toRgb(
+            resolve('colors.primary.foreground', fallbacks.white),
+            fallbacks.white
+          ),
+          '--mp-border-rgb': toRgb(
+            resolve('colors.border.DEFAULT', fallbacks.gray200),
+            fallbacks.gray200
+          ),
+          '--mp-border-muted-rgb': toRgb(
+            resolve('colors.border.muted', fallbacks.gray300),
+            fallbacks.gray300
+          ),
+          '--mp-muted-rgb': toRgb(
+            resolve('colors.foreground.muted', fallbacks.gray700),
+            fallbacks.gray700
+          ),
           '--mp-destructive-rgb': destructive,
           '--mp-destructive-hover-rgb': destructiveHover,
-          '--mp-destructive-foreground-rgb': toRgb(resolve('colors.destructive.foreground', fallbacks.white), fallbacks.white),
+          '--mp-destructive-foreground-rgb': toRgb(
+            resolve('colors.destructive.foreground', fallbacks.white),
+            fallbacks.white
+          ),
           '--mp-success-rgb': success,
           '--mp-success-hover-rgb': successHover,
-          '--mp-success-foreground-rgb': toRgb(resolve('colors.success.foreground', fallbacks.white), fallbacks.white),
+          '--mp-success-foreground-rgb': toRgb(
+            resolve('colors.success.foreground', fallbacks.white),
+            fallbacks.white
+          ),
           '--mp-warning-rgb': warning,
           '--mp-warning-hover-rgb': warningHover,
-          '--mp-warning-foreground-rgb': toRgb(resolve('colors.warning.foreground', fallbacks.black), fallbacks.black),
-          '--mp-accent-rgb': toRgb(resolve('colors.accent.DEFAULT', fallbacks.gray100), fallbacks.gray100),
-          '--mp-accent-hover-rgb': toRgb(resolve('colors.accent.hover', fallbacks.gray200), fallbacks.gray200),
-          '--mp-accent-foreground-rgb': toRgb(resolve('colors.accent.foreground', fallbacks.gray700), fallbacks.gray700),
+          '--mp-warning-foreground-rgb': toRgb(
+            resolve('colors.warning.foreground', fallbacks.black),
+            fallbacks.black
+          ),
+          '--mp-accent-rgb': toRgb(
+            resolve('colors.accent.DEFAULT', fallbacks.gray100),
+            fallbacks.gray100
+          ),
+          '--mp-accent-hover-rgb': toRgb(
+            resolve('colors.accent.hover', fallbacks.gray200),
+            fallbacks.gray200
+          ),
+          '--mp-accent-foreground-rgb': toRgb(
+            resolve('colors.accent.foreground', fallbacks.gray700),
+            fallbacks.gray700
+          ),
           '--mp-border-radius': '0.375rem',
           // Backwards-compat: also set non -rgb vars to the same triplets
-          '--mp-background': toRgb(resolve('colors.background.DEFAULT', fallbacks.white), fallbacks.white),
-          '--mp-background-secondary': toRgb(resolve('colors.background.secondary', fallbacks.gray100), fallbacks.gray100),
-          '--mp-foreground': toRgb(resolve('colors.foreground.DEFAULT', fallbacks.gray900), fallbacks.gray900),
-          '--mp-foreground-secondary': toRgb(resolve('colors.foreground.secondary', fallbacks.gray700), fallbacks.gray700),
+          '--mp-background': toRgb(
+            resolve('colors.background.DEFAULT', fallbacks.white),
+            fallbacks.white
+          ),
+          '--mp-background-secondary': toRgb(
+            resolve('colors.background.secondary', fallbacks.gray100),
+            fallbacks.gray100
+          ),
+          '--mp-foreground': toRgb(
+            resolve('colors.foreground.DEFAULT', fallbacks.gray900),
+            fallbacks.gray900
+          ),
+          '--mp-foreground-secondary': toRgb(
+            resolve('colors.foreground.secondary', fallbacks.gray700),
+            fallbacks.gray700
+          ),
           '--mp-primary': primary,
           '--mp-primary-hover': primaryHover,
-          '--mp-primary-foreground': toRgb(resolve('colors.primary.foreground', fallbacks.white), fallbacks.white),
-          '--mp-border': toRgb(resolve('colors.border.DEFAULT', fallbacks.gray200), fallbacks.gray200),
-          '--mp-border-muted': toRgb(resolve('colors.border.muted', fallbacks.gray300), fallbacks.gray300),
-          '--mp-muted': toRgb(resolve('colors.foreground.muted', fallbacks.gray700), fallbacks.gray700),
+          '--mp-primary-foreground': toRgb(
+            resolve('colors.primary.foreground', fallbacks.white),
+            fallbacks.white
+          ),
+          '--mp-border': toRgb(
+            resolve('colors.border.DEFAULT', fallbacks.gray200),
+            fallbacks.gray200
+          ),
+          '--mp-border-muted': toRgb(
+            resolve('colors.border.muted', fallbacks.gray300),
+            fallbacks.gray300
+          ),
+          '--mp-muted': toRgb(
+            resolve('colors.foreground.muted', fallbacks.gray700),
+            fallbacks.gray700
+          ),
           '--mp-destructive': destructive,
           '--mp-destructive-hover': destructiveHover,
-          '--mp-destructive-foreground': toRgb(resolve('colors.destructive.foreground', fallbacks.white), fallbacks.white),
+          '--mp-destructive-foreground': toRgb(
+            resolve('colors.destructive.foreground', fallbacks.white),
+            fallbacks.white
+          ),
           '--mp-success': success,
           '--mp-success-hover': successHover,
-          '--mp-success-foreground': toRgb(resolve('colors.success.foreground', fallbacks.white), fallbacks.white),
+          '--mp-success-foreground': toRgb(
+            resolve('colors.success.foreground', fallbacks.white),
+            fallbacks.white
+          ),
           '--mp-warning': warning,
           '--mp-warning-hover': warningHover,
-          '--mp-warning-foreground': toRgb(resolve('colors.warning.foreground', fallbacks.black), fallbacks.black),
-          '--mp-accent': toRgb(resolve('colors.accent.DEFAULT', fallbacks.gray100), fallbacks.gray100),
-          '--mp-accent-hover': toRgb(resolve('colors.accent.hover', fallbacks.gray200), fallbacks.gray200),
-          '--mp-accent-foreground': toRgb(resolve('colors.accent.foreground', fallbacks.gray700), fallbacks.gray700),
+          '--mp-warning-foreground': toRgb(
+            resolve('colors.warning.foreground', fallbacks.black),
+            fallbacks.black
+          ),
+          '--mp-accent': toRgb(
+            resolve('colors.accent.DEFAULT', fallbacks.gray100),
+            fallbacks.gray100
+          ),
+          '--mp-accent-hover': toRgb(
+            resolve('colors.accent.hover', fallbacks.gray200),
+            fallbacks.gray200
+          ),
+          '--mp-accent-foreground': toRgb(
+            resolve('colors.accent.foreground', fallbacks.gray700),
+            fallbacks.gray700
+          ),
         },
         '.dark, [data-theme="dark"]': {
-          '--mp-background-rgb': toRgb(resolve('colors.background.dark', fallbacks.zinc900), fallbacks.zinc900),
-          '--mp-background-secondary-rgb': toRgb(resolve('colors.background.darkSecondary', fallbacks.gray800), fallbacks.gray800),
-          '--mp-foreground-rgb': toRgb(resolve('colors.foreground.dark', fallbacks.zinc100), fallbacks.zinc100),
-          '--mp-foreground-secondary-rgb': toRgb(resolve('colors.foreground.darkSecondary', fallbacks.gray300), fallbacks.gray300),
-          '--mp-border-rgb': toRgb(resolve('colors.border.dark', fallbacks.gray700), fallbacks.gray700),
-          '--mp-border-muted-rgb': toRgb(resolve('colors.border.darkMuted', fallbacks.gray700), fallbacks.gray700),
-          '--mp-accent-rgb': toRgb(resolve('colors.accent.dark', fallbacks.gray800), fallbacks.gray800),
-          '--mp-accent-hover-rgb': toRgb(resolve('colors.accent.darkHover', fallbacks.gray700), fallbacks.gray700),
+          '--mp-background-rgb': toRgb(
+            resolve('colors.background.dark', fallbacks.zinc900),
+            fallbacks.zinc900
+          ),
+          '--mp-background-secondary-rgb': toRgb(
+            resolve('colors.background.darkSecondary', fallbacks.gray800),
+            fallbacks.gray800
+          ),
+          '--mp-foreground-rgb': toRgb(
+            resolve('colors.foreground.dark', fallbacks.zinc100),
+            fallbacks.zinc100
+          ),
+          '--mp-foreground-secondary-rgb': toRgb(
+            resolve('colors.foreground.darkSecondary', fallbacks.gray300),
+            fallbacks.gray300
+          ),
+          '--mp-muted-rgb': toRgb(
+            resolve('colors.foreground.darkMuted', fallbacks.gray300),
+            fallbacks.gray300
+          ),
+          '--mp-border-rgb': toRgb(
+            resolve('colors.border.dark', fallbacks.gray700),
+            fallbacks.gray700
+          ),
+          '--mp-border-muted-rgb': toRgb(
+            resolve('colors.border.darkMuted', fallbacks.gray700),
+            fallbacks.gray700
+          ),
+          '--mp-accent-rgb': toRgb(
+            resolve('colors.accent.dark', fallbacks.gray800),
+            fallbacks.gray800
+          ),
+          '--mp-accent-hover-rgb': toRgb(
+            resolve('colors.accent.darkHover', fallbacks.gray700),
+            fallbacks.gray700
+          ),
           // Backwards-compat mirror
-          '--mp-background': toRgb(resolve('colors.background.dark', fallbacks.zinc900), fallbacks.zinc900),
-          '--mp-background-secondary': toRgb(resolve('colors.background.darkSecondary', fallbacks.gray800), fallbacks.gray800),
-          '--mp-foreground': toRgb(resolve('colors.foreground.dark', fallbacks.zinc100), fallbacks.zinc100),
-          '--mp-foreground-secondary': toRgb(resolve('colors.foreground.darkSecondary', fallbacks.gray300), fallbacks.gray300),
+          '--mp-background': toRgb(
+            resolve('colors.background.dark', fallbacks.zinc900),
+            fallbacks.zinc900
+          ),
+          '--mp-background-secondary': toRgb(
+            resolve('colors.background.darkSecondary', fallbacks.gray800),
+            fallbacks.gray800
+          ),
+          '--mp-foreground': toRgb(
+            resolve('colors.foreground.dark', fallbacks.zinc100),
+            fallbacks.zinc100
+          ),
+          '--mp-foreground-secondary': toRgb(
+            resolve('colors.foreground.darkSecondary', fallbacks.gray300),
+            fallbacks.gray300
+          ),
+          '--mp-muted': toRgb(
+            resolve('colors.foreground.darkMuted', fallbacks.gray300),
+            fallbacks.gray300
+          ),
           '--mp-border': toRgb(resolve('colors.border.dark', fallbacks.gray700), fallbacks.gray700),
-          '--mp-border-muted': toRgb(resolve('colors.border.darkMuted', fallbacks.gray700), fallbacks.gray700),
+          '--mp-border-muted': toRgb(
+            resolve('colors.border.darkMuted', fallbacks.gray700),
+            fallbacks.gray700
+          ),
           '--mp-accent': toRgb(resolve('colors.accent.dark', fallbacks.gray800), fallbacks.gray800),
-          '--mp-accent-hover': toRgb(resolve('colors.accent.darkHover', fallbacks.gray700), fallbacks.gray700),
-          // Keep primary/semantic status colors, but consumers can override with their own dark tokens}
+          '--mp-accent-hover': toRgb(
+            resolve('colors.accent.darkHover', fallbacks.gray700),
+            fallbacks.gray700
+          ),
+          // Keep primary/semantic status colors, but consumers can override with their own dark tokens
         },
       });
     },

--- a/tests/tailwind-preset.test.ts
+++ b/tests/tailwind-preset.test.ts
@@ -1,0 +1,72 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+type BaseStyles = Partial<Record<string, Record<string, string | undefined>>>;
+
+interface TailwindPluginContext {
+  addBase: (styles: BaseStyles) => void;
+  theme: (path: string) => string | undefined;
+}
+
+interface TailwindPreset {
+  plugins: [
+    (context: TailwindPluginContext) => void,
+    ...Array<(context: TailwindPluginContext) => void>,
+  ];
+}
+
+const require = createRequire(import.meta.url);
+const preset = require('../tailwind-preset.cjs') as TailwindPreset;
+
+const renderBaseStyles = (themeValues: Record<string, string> = {}) => {
+  let baseStyles: BaseStyles = {};
+  const plugin = preset.plugins[0];
+
+  plugin({
+    addBase(styles) {
+      baseStyles = styles;
+    },
+    theme: (path) => themeValues[path],
+  });
+
+  return baseStyles;
+};
+
+const getRule = (styles: BaseStyles, selector: string) => {
+  const rule = styles[selector];
+  if (rule === undefined) {
+    throw new Error(`Missing base rule for ${selector}`);
+  }
+  return rule;
+};
+
+describe('tailwind preset color token generation', () => {
+  it('normalizes supported CSS colors to RGB triplets', () => {
+    const root = getRule(
+      renderBaseStyles({
+        'colors.background.DEFAULT': 'oklch(1 0 0)',
+        'colors.foreground.DEFAULT': '#1234',
+        'colors.primary.500': 'rgba(255, 128, 64, 0.5)',
+        'colors.primary.600': 'hsl(120 100% 25%)',
+      }),
+      ':root'
+    );
+
+    expect(root['--mp-background-rgb']).toBe('255 255 255');
+    expect(root['--mp-foreground-rgb']).toBe('17 34 51');
+    expect(root['--mp-primary-rgb']).toBe('255 128 64');
+    expect(root['--mp-primary-hover-rgb']).toBe('0 128 0');
+  });
+
+  it('sets dark muted foreground variables independently', () => {
+    const dark = getRule(
+      renderBaseStyles({
+        'colors.foreground.darkMuted': 'hsl(0 0% 80%)',
+      }),
+      '.dark, [data-theme="dark"]'
+    );
+
+    expect(dark['--mp-muted-rgb']).toBe('204 204 204');
+    expect(dark['--mp-muted']).toBe('204 204 204');
+  });
+});


### PR DESCRIPTION
## Summary

Addresses the actionable PR 48 review feedback by:

- expanding the Tailwind preset color parser to handle `rgba`, `hsl`, `oklch`, and hex alpha forms without silently falling back
- adding dark-mode muted foreground variables and removing the stray comment brace
- adding least-privilege CI permissions
- moving packaging validation into a shared `validate:packaging` script used by CI and publish workflows
- fixing README/docs examples for React 19 installs and provider imports
- adding regression tests for Tailwind preset token generation

## Validation

- `./node_modules/.bin/vitest --run` passed: 7 files, 20 passed, 4 skipped
- `./node_modules/.bin/tsc --noEmit` passed
- `./node_modules/.bin/eslint tests/tailwind-preset.test.ts` passed
- `git diff --check` passed

## Known Local Blockers

- `pnpm exec` is blocked locally by pnpm ignored-build approvals for `esbuild` and `unrs-resolver`, so validation used local binaries.
- Full `eslint .` still fails on pre-existing upgraded-rule issues outside this patch.
- `tsc -b` / package build is blocked by existing AI SDK dependency migration issues (`LanguageModelV3/V4` returned where the source still declares `LanguageModelV2`) plus upgraded ESLint/Vite config typing errors. Because build cannot complete, `publint --strict` also fails on the missing generated `dist/index.d.cts` file that the build normally copies.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/ai-sdk-react-model-picker/pull/49?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

