### PR TITLE
Add Qwen, Z.ai, and Claude Code providers with improved validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Built-in providers:
 
 - **OpenAI** - GPT-4o, GPT-4 Turbo, GPT-3.5 Turbo
 - **Anthropic** - Claude 3.5 Sonnet, Claude 3 Opus/Sonnet/Haiku
+- **Claude Code** - Claude Opus/Sonnet/Haiku via the Claude Code CLI (subscription auth, no API key)
 - **Google** - Gemini 1.5 Pro/Flash, Gemini Pro
 - **Azure OpenAI** - Azure-hosted OpenAI models
 - **Mistral** - Mistral Large/Medium/Small, Codestral

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ Built-in providers:
 - **Azure OpenAI** - Azure-hosted OpenAI models
 - **Mistral** - Mistral Large/Medium/Small, Codestral
 - **Cohere** - Command R+, Command R, Command
+- **Qwen** - Qwen3 Max, Qwen3 Coder Plus, Qwen Plus/Turbo (Alibaba Cloud Model Studio)
+- **Z.ai (GLM)** - GLM 4.6, GLM 4.5, GLM 4.5 Air (Zhipu AI)
 
 ### Storage Adapters
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-sdk-react-model-picker",
   "private": false,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A flexible, theme-aware React component library for selecting and managing AI models. Built for seamless integration with Vercel's AI SDK v5, with special support for VSCode extensions and JetBrains IDEs.",
   "homepage": "https://github.com/hbmartin/ai-sdk-react-model-picker",
   "bugs": "https://github.com/hbmartin/ai-sdk-react-model-picker/issues",
@@ -109,6 +109,7 @@
     "@ai-sdk/openai": ">=2.0.0",
     "@ai-sdk/openai-compatible": ">=1.0.0",
     "@openrouter/ai-sdk-provider": ">=1.0.0",
+    "ai-sdk-provider-claude-code": ">=1.0.0 <3.0.0",
     "ollama-ai-provider-v2": ">=1.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -150,6 +151,9 @@
     },
     "ollama-ai-provider-v2": {
       "optional": true
+    },
+    "ai-sdk-provider-claude-code": {
+      "optional": true
     }
   },
   "devDependencies": {
@@ -180,6 +184,7 @@
     "@vitejs/plugin-react": "^5.0.4",
     "@vitest/ui": "^3.2.4",
     "ai": "^5.0.60",
+    "ai-sdk-provider-claude-code": "^2.3.0",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.36.0",
     "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       ai:
         specifier: ^5.0.60
         version: 5.0.60(zod@4.1.8)
+      ai-sdk-provider-claude-code:
+        specifier: ^2.3.0
+        version: 2.3.0(zod@4.1.8)
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
@@ -257,6 +260,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@3.0.9':
+    resolution: {integrity: sha512-Pm571x5efqaI4hf9yW4KsVlDBDme8++UepZRnq+kqVBWWjgvGhQlzU8glaFq0YJEB9kkxZHbRRyVeHoV2sRYaQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
   '@ai-sdk/provider@2.0.0':
     resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
     engines: {node: '>=18'}
@@ -267,6 +276,12 @@ packages:
 
   '@andrewbranch/untar.js@1.0.3':
     resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
+
+  '@anthropic-ai/claude-agent-sdk@0.1.77':
+    resolution: {integrity: sha512-ZEjWQtkoB2MEY6K16DWMmF+8OhywAynH0m08V265cerbZ8xPD/2Ng2jPzbbO40mPeFSsMDJboShL+a3aObP0Jg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   '@arethetypeswrong/cli@0.18.2':
     resolution: {integrity: sha512-PcFM20JNlevEDKBg4Re29Rtv2xvjvQZzg7ENnrWFSS0PHgdP2njibVFw+dRUhNkPgNfac9iUqO0ohAXqQL4hbw==}
@@ -679,6 +694,99 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@img/sharp-darwin-arm64@0.33.5':
+    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.33.5':
+    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.33.5':
+    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.33.5':
+    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.33.5':
+    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-win32-x64@0.33.5':
+    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
   '@isaacs/balanced-match@4.0.1':
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
     engines: {node: 20 || >=22}
@@ -825,56 +933,67 @@ packages:
     resolution: {integrity: sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.4':
     resolution: {integrity: sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.4':
     resolution: {integrity: sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.4':
     resolution: {integrity: sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.4':
     resolution: {integrity: sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.4':
     resolution: {integrity: sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.4':
     resolution: {integrity: sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.4':
     resolution: {integrity: sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.4':
     resolution: {integrity: sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.4':
     resolution: {integrity: sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.4':
     resolution: {integrity: sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.4':
     resolution: {integrity: sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==}
@@ -976,6 +1095,9 @@ packages:
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@storybook/addon-docs@9.1.10':
     resolution: {integrity: sha512-LYK3oXy/0PgY39FhkYVd9D0bzatLGTsMhaPPwSjBOmZgK0f0yBLqaePy7urUFeHYm/rjwAaRmDJNBqUnGTVoig==}
@@ -1234,41 +1356,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1376,6 +1506,12 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ai-sdk-provider-claude-code@2.3.0:
+    resolution: {integrity: sha512-iUP1v4DUPITgW3I4hSF3tCVBTv2q9F6CKR96Y1lOYqQUjjeZunv2MqImnCsIBvDdmCLu/Qj8+iVAmNaaN4iqTg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0 || ^4.0.0
 
   ai@5.0.60:
     resolution: {integrity: sha512-80U/3kmdBW6g+JkLXpz/P2EwkyEaWlPlYtuLUpx/JYK9F7WZh9NnkYoh1KvUi1Sbpo0NyurBTvX0a2AG9mmbDA==}
@@ -2045,6 +2181,10 @@ packages:
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
   expect-type@1.2.2:
@@ -3698,6 +3838,13 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 4.1.8
 
+  '@ai-sdk/provider-utils@3.0.9(zod@4.1.8)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.1.8
+
   '@ai-sdk/provider@2.0.0':
     dependencies:
       json-schema: 0.4.0
@@ -3705,6 +3852,19 @@ snapshots:
   '@alloc/quick-lru@5.2.0': {}
 
   '@andrewbranch/untar.js@1.0.3': {}
+
+  '@anthropic-ai/claude-agent-sdk@0.1.77(zod@4.1.8)':
+    dependencies:
+      zod: 4.1.8
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.33.5
+      '@img/sharp-darwin-x64': 0.33.5
+      '@img/sharp-linux-arm': 0.33.5
+      '@img/sharp-linux-arm64': 0.33.5
+      '@img/sharp-linux-x64': 0.33.5
+      '@img/sharp-linuxmusl-arm64': 0.33.5
+      '@img/sharp-linuxmusl-x64': 0.33.5
+      '@img/sharp-win32-x64': 0.33.5
 
   '@arethetypeswrong/cli@0.18.2':
     dependencies:
@@ -4106,6 +4266,65 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@img/sharp-darwin-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.0.5
+    optional: true
+
+  '@img/sharp-linux-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-win32-x64@0.33.5':
+    optional: true
+
   '@isaacs/balanced-match@4.0.1': {}
 
   '@isaacs/brace-expansion@5.0.0':
@@ -4392,6 +4611,8 @@ snapshots:
       tslib: 2.8.1
 
   '@standard-schema/spec@1.0.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@storybook/addon-docs@9.1.10(@types/react@19.2.0)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.9(@types/node@20.19.1)(jiti@2.6.1)(yaml@2.8.1)))':
     dependencies:
@@ -4844,6 +5065,13 @@ snapshots:
   acorn@8.15.0: {}
 
   agent-base@7.1.4: {}
+
+  ai-sdk-provider-claude-code@2.3.0(zod@4.1.8):
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.9(zod@4.1.8)
+      '@anthropic-ai/claude-agent-sdk': 0.1.77(zod@4.1.8)
+      zod: 4.1.8
 
   ai@5.0.60(zod@4.1.8):
     dependencies:
@@ -5682,6 +5910,8 @@ snapshots:
   esutils@2.0.3: {}
 
   eventsource-parser@3.0.6: {}
+
+  eventsource-parser@3.1.0: {}
 
   expect-type@1.2.2: {}
 

--- a/src/lib/components/AddModelForm.tsx
+++ b/src/lib/components/AddModelForm.tsx
@@ -80,6 +80,7 @@ export function AddModelForm({
     formState: { errors, isValid, isSubmitting },
     reset,
     getFieldState,
+    getValues,
   } = useForm<AddModelFormData>({
     mode: 'onTouched',
   });
@@ -184,7 +185,12 @@ export function AddModelForm({
     if (selectedProvider === undefined) {
       return 'Provider is required';
     }
-    const fieldValidation = selectedProvider.configuration.validateField(key, value);
+    const formValues = Object.fromEntries(
+      Object.entries(getValues()).filter(
+        (entry): entry is [string, string] => typeof entry[1] === 'string'
+      )
+    );
+    const fieldValidation = selectedProvider.configuration.validateField(key, value, formValues);
     const hasValue = value !== undefined && value.trim().length > 0;
     const { isDirty } = getFieldState(key);
     if (fieldValidation?.error !== undefined) {

--- a/src/lib/icons/index.ts
+++ b/src/lib/icons/index.ts
@@ -84,6 +84,32 @@ export const MoonshotIcon: IconComponent = (props) =>
     })
   );
 
+export const QwenIcon: IconComponent = (props) =>
+  createElement(
+    'svg',
+    {
+      viewBox: '0 0 24 24',
+      fill: 'currentColor',
+      ...props,
+    },
+    createElement('path', {
+      d: 'M23.919 14.545 20.817 9.17l1.47-2.544a.56.56 0 0 0 0-.566l-1.633-2.83a.57.57 0 0 0-.49-.283h-6.207L12.487.402a.57.57 0 0 0-.49-.284H8.732a.56.56 0 0 0-.49.284L5.139 5.775h-2.94a.56.56 0 0 0-.49.284L.077 8.887a.56.56 0 0 0 0 .567L3.18 14.83l-1.47 2.545a.56.56 0 0 0 0 .566l1.634 2.83a.57.57 0 0 0 .49.283h6.205l1.47 2.545a.57.57 0 0 0 .49.284h3.266a.57.57 0 0 0 .49-.284l3.104-5.375h2.94a.57.57 0 0 0 .49-.283l1.634-2.828a.55.55 0 0 0-.004-.568M8.733.686l1.634 2.828-1.634 2.828H21.8L20.164 9.17H7.425L5.63 6.06Zm1.306 19.801-6.205-.002 1.634-2.83h3.265L2.201 6.344h3.267q3.182 5.517 6.367 11.032zm10.124-5.66L18.53 12l-6.532 11.315-1.634-2.83c2.129-3.673 4.25-7.351 6.373-11.028h3.592l3.102 5.374z',
+    })
+  );
+
+export const ZaiIcon: IconComponent = (props) =>
+  createElement(
+    'svg',
+    {
+      viewBox: '0 0 24 24',
+      fill: 'currentColor',
+      ...props,
+    },
+    createElement('path', {
+      d: 'M4 3.5h16v3.2L9.9 17.3H20v3.2H4v-3.2L14.1 6.7H4z',
+    })
+  );
+
 export const BedrockIcon: IconComponent = (props) =>
   createElement(
     'svg',

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -33,6 +33,8 @@ export { AzureProvider } from './providers/AzureProvider';
 export { GoogleProvider } from './providers/GoogleProvider';
 export { MistralProvider } from './providers/MistralProvider';
 export { CohereProvider } from './providers/CohereProvider';
+export { QwenProvider } from './providers/QwenProvider';
+export { ZaiProvider } from './providers/ZaiProvider';
 export { makeConfiguration, apiKeyField, baseUrlField } from './providers/configuration';
 export type {
   ConfigAPI,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -27,6 +27,7 @@ export type { VSCodeContext, UniversalTheme } from './hooks';
 export { createDefaultRegistry, allProviders } from './providers';
 export { ProviderRegistry } from './providers/ProviderRegistry';
 export { AnthropicProvider } from './providers/AnthropicProvider';
+export { ClaudeCodeProvider } from './providers/ClaudeCodeProvider';
 export { OpenAIProvider } from './providers/OpenAIProvider';
 export { AzureProvider } from './providers/AzureProvider';
 export { GoogleProvider } from './providers/GoogleProvider';

--- a/src/lib/providers/ClaudeCodeProvider.ts
+++ b/src/lib/providers/ClaudeCodeProvider.ts
@@ -1,0 +1,89 @@
+type ClaudeCodeModule = typeof import('ai-sdk-provider-claude-code');
+import type { LanguageModelV2 } from '@ai-sdk/provider';
+import type { ModelConfig, ProviderMetadata, ProviderInstanceParams } from '../types';
+import { AIProvider, createProviderId, createModelId } from '../types';
+import { ClaudeIcon } from '../icons';
+import { makeConfiguration, type ConfigAPI } from './configuration';
+import type { ClaudeCodeSettings } from 'ai-sdk-provider-claude-code';
+
+/**
+ * String-valued subset of ClaudeCodeSettings that can be collected through
+ * the configuration form. Auth happens through the Claude Code CLI login,
+ * so no API key is required.
+ */
+type ClaudeCodeConfig = Pick<ClaudeCodeSettings, 'cwd' | 'pathToClaudeCodeExecutable'>;
+
+export class ClaudeCodeProvider extends AIProvider {
+  override readonly metadata: ProviderMetadata = {
+    id: createProviderId('claude-code'),
+    name: 'Claude Code',
+    description: 'Use your Claude subscription through the Claude Code CLI — no API key required.',
+    icon: ClaudeIcon,
+    documentationUrl: 'https://docs.anthropic.com/en/docs/claude-code/overview',
+  };
+
+  override readonly models: ModelConfig[] = [
+    {
+      id: createModelId('sonnet'),
+      displayName: 'Claude Sonnet',
+      supportsVision: true,
+      supportsTools: true,
+      isDefault: true,
+      origin: 'builtin',
+      visible: true,
+    },
+    {
+      id: createModelId('opus'),
+      displayName: 'Claude Opus',
+      supportsVision: true,
+      supportsTools: true,
+      origin: 'builtin',
+      visible: true,
+    },
+    {
+      id: createModelId('haiku'),
+      displayName: 'Claude Haiku',
+      supportsVision: true,
+      supportsTools: true,
+      origin: 'builtin',
+      visible: true,
+    },
+  ];
+
+  override readonly configuration: ConfigAPI<ClaudeCodeConfig> =
+    makeConfiguration<ClaudeCodeConfig>()({
+      fields: [
+        {
+          key: 'pathToClaudeCodeExecutable',
+          label: 'Path to Claude Code executable (optional)',
+          placeholder: 'claude',
+        },
+        {
+          key: 'cwd',
+          label: 'Working directory (optional)',
+          placeholder: '/path/to/project',
+        },
+      ],
+    });
+
+  async createInstance(params: ProviderInstanceParams): Promise<LanguageModelV2> {
+    // Dynamic import to avoid bundling if not needed
+    let claudeCodeModule: ClaudeCodeModule;
+
+    try {
+      // This will be a peer dependency
+      claudeCodeModule = await import('ai-sdk-provider-claude-code');
+    } catch {
+      throw new Error(
+        'Claude Code provider requires "ai-sdk-provider-claude-code" to be installed. ' +
+          'Please install it with: npm install ai-sdk-provider-claude-code'
+      );
+    }
+
+    const options = params.options ?? {};
+    this.configuration.assertValidConfigAndRemoveEmptyKeys(options);
+
+    const client = claudeCodeModule.createClaudeCode({ defaultSettings: options });
+    return client(params.model);
+  }
+}

--- a/src/lib/providers/LmStudioProvider.ts
+++ b/src/lib/providers/LmStudioProvider.ts
@@ -6,11 +6,11 @@ import { AIProvider, createModelId, createProviderId, isObject } from '../types'
 import { LmStudioIcon } from '../icons';
 import { baseUrlField, makeConfiguration, type ConfigAPI } from './configuration';
 
-type LmStudioModelType = 'llm' | 'embeddings';
-
 interface LmStudioModel {
   id: string;
-  type: LmStudioModelType;
+  // '/api/v0/models' returns 'llm', 'vlm', and 'embeddings' today, but the set
+  // is not documented as closed — treat any other value as a usable model
+  type: string;
   max_context_length?: number;
   capabilities?: string[];
 }
@@ -31,11 +31,11 @@ function isLmStudioModel(value: unknown): value is LmStudioModel {
     capabilities?: unknown;
   };
 
-  if (typeof candidate.id !== 'string') {
+  if (typeof candidate.id !== 'string' || candidate.id.trim().length === 0) {
     return false;
   }
 
-  if (candidate.type !== 'llm' && candidate.type !== 'embeddings') {
+  if (typeof candidate.type !== 'string') {
     return false;
   }
 
@@ -64,11 +64,7 @@ function isLmStudioModelListResponse(value: unknown): value is LmStudioModelList
 
   const candidate = value as { data?: unknown };
 
-  if (!Array.isArray(candidate.data)) {
-    return false;
-  }
-
-  return candidate.data.every((item) => isLmStudioModel(item));
+  return Array.isArray(candidate.data);
 }
 
 export class LmStudioProvider extends AIProvider {
@@ -124,14 +120,19 @@ export class LmStudioProvider extends AIProvider {
       throw new TypeError('Unexpected LM Studio model list response payload');
     }
 
+    // Skip entries we don't understand instead of rejecting the whole list;
+    // with JIT loading enabled the list includes every downloaded model
+    // (loaded or not), and formats vary across LM Studio versions.
     // TODO: consider how discoveredAt effects sorting
     return payload.data
+      .filter((model) => isLmStudioModel(model))
       .filter((model) => model.type !== 'embeddings')
       .map((model) => ({
         id: createModelId(model.id),
         displayName: model.id,
         contextLength: model.max_context_length,
         supportsTools: model.capabilities?.includes('tool_use') ?? false,
+        supportsVision: model.type === 'vlm' || (model.capabilities?.includes('vision') ?? false),
         discoveredAt: Date.now(),
       }));
   }

--- a/src/lib/providers/QwenProvider.ts
+++ b/src/lib/providers/QwenProvider.ts
@@ -1,0 +1,94 @@
+type OpenAICompatibleModule = typeof import('@ai-sdk/openai-compatible');
+import type { OpenAICompatibleProviderSettings } from '@ai-sdk/openai-compatible';
+import type { LanguageModelV2 } from '@ai-sdk/provider';
+import {
+  AIProvider,
+  type ProviderMetadata,
+  type ModelConfig,
+  type ProviderInstanceParams,
+  createProviderId,
+  createModelId,
+} from '../types';
+import { QwenIcon } from '../icons';
+import { apiKeyField, baseUrlField, makeConfiguration, type ConfigAPI } from './configuration';
+
+const DEFAULT_BASE_URL = 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1';
+
+export class QwenProvider extends AIProvider {
+  override readonly metadata: ProviderMetadata = {
+    id: createProviderId('qwen'),
+    name: 'Qwen',
+    description: 'Qwen 3 and other Alibaba Cloud Model Studio (DashScope) models',
+    icon: QwenIcon,
+    documentationUrl: 'https://www.alibabacloud.com/help/en/model-studio/models',
+    apiKeyUrl: 'https://bailian.console.alibabacloud.com/?tab=model#/api-key',
+  };
+
+  override readonly models: ModelConfig[] = [
+    {
+      id: createModelId('qwen3-max'),
+      displayName: 'Qwen3 Max',
+      contextLength: 256_000,
+      supportsTools: true,
+      isDefault: true,
+      origin: 'builtin',
+      visible: true,
+    },
+    {
+      id: createModelId('qwen3-coder-plus'),
+      displayName: 'Qwen3 Coder Plus',
+      contextLength: 256_000,
+      supportsTools: true,
+      origin: 'builtin',
+      visible: true,
+    },
+    {
+      id: createModelId('qwen-plus'),
+      displayName: 'Qwen Plus',
+      contextLength: 128_000,
+      supportsTools: true,
+      origin: 'builtin',
+      visible: true,
+    },
+    {
+      id: createModelId('qwen-turbo'),
+      displayName: 'Qwen Turbo',
+      contextLength: 128_000,
+      supportsTools: true,
+      origin: 'builtin',
+      visible: true,
+    },
+  ];
+
+  override readonly configuration: ConfigAPI<OpenAICompatibleProviderSettings> =
+    makeConfiguration<OpenAICompatibleProviderSettings>()({
+      // Mainland China accounts use https://dashscope.aliyuncs.com/compatible-mode/v1
+      fields: [apiKeyField('sk-', true), baseUrlField(DEFAULT_BASE_URL)],
+    });
+
+  async createInstance(params: ProviderInstanceParams): Promise<LanguageModelV2> {
+    // Dynamic import to avoid bundling if not needed
+    let openai: OpenAICompatibleModule;
+
+    try {
+      // This will be a peer dependency
+      openai = await import('@ai-sdk/openai-compatible');
+    } catch {
+      throw new Error(
+        'Qwen provider requires "@ai-sdk/openai-compatible" to be installed. ' +
+          'Please install it with: npm install @ai-sdk/openai-compatible'
+      );
+    }
+
+    const options = params.options ?? {};
+    this.configuration.assertValidConfigAndRemoveEmptyKeys(options);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    options.baseURL ??= DEFAULT_BASE_URL;
+    const client = openai.createOpenAICompatible({
+      ...options,
+      name: 'qwen',
+      baseURL: options.baseURL,
+    });
+    return client(params.model);
+  }
+}

--- a/src/lib/providers/ZaiProvider.ts
+++ b/src/lib/providers/ZaiProvider.ts
@@ -1,0 +1,86 @@
+type OpenAICompatibleModule = typeof import('@ai-sdk/openai-compatible');
+import type { OpenAICompatibleProviderSettings } from '@ai-sdk/openai-compatible';
+import type { LanguageModelV2 } from '@ai-sdk/provider';
+import {
+  AIProvider,
+  type ProviderMetadata,
+  type ModelConfig,
+  type ProviderInstanceParams,
+  createProviderId,
+  createModelId,
+} from '../types';
+import { ZaiIcon } from '../icons';
+import { apiKeyField, baseUrlField, makeConfiguration, type ConfigAPI } from './configuration';
+
+const DEFAULT_BASE_URL = 'https://api.z.ai/api/paas/v4';
+
+export class ZaiProvider extends AIProvider {
+  override readonly metadata: ProviderMetadata = {
+    id: createProviderId('zai'),
+    name: 'Z.ai (GLM)',
+    description: 'GLM-4.6 and other Zhipu AI models',
+    icon: ZaiIcon,
+    documentationUrl: 'https://docs.z.ai/guides/llm/glm-4.6',
+    apiKeyUrl: 'https://z.ai/manage-apikey/apikey-list',
+  };
+
+  override readonly models: ModelConfig[] = [
+    {
+      id: createModelId('glm-4.6'),
+      displayName: 'GLM 4.6',
+      contextLength: 200_000,
+      supportsTools: true,
+      isDefault: true,
+      origin: 'builtin',
+      visible: true,
+    },
+    {
+      id: createModelId('glm-4.5'),
+      displayName: 'GLM 4.5',
+      contextLength: 128_000,
+      supportsTools: true,
+      origin: 'builtin',
+      visible: true,
+    },
+    {
+      id: createModelId('glm-4.5-air'),
+      displayName: 'GLM 4.5 Air',
+      contextLength: 128_000,
+      supportsTools: true,
+      origin: 'builtin',
+      visible: true,
+    },
+  ];
+
+  override readonly configuration: ConfigAPI<OpenAICompatibleProviderSettings> =
+    makeConfiguration<OpenAICompatibleProviderSettings>()({
+      // Mainland China accounts use https://open.bigmodel.cn/api/paas/v4
+      fields: [apiKeyField(16, true), baseUrlField(DEFAULT_BASE_URL)],
+    });
+
+  async createInstance(params: ProviderInstanceParams): Promise<LanguageModelV2> {
+    // Dynamic import to avoid bundling if not needed
+    let openai: OpenAICompatibleModule;
+
+    try {
+      // This will be a peer dependency
+      openai = await import('@ai-sdk/openai-compatible');
+    } catch {
+      throw new Error(
+        'Z.ai provider requires "@ai-sdk/openai-compatible" to be installed. ' +
+          'Please install it with: npm install @ai-sdk/openai-compatible'
+      );
+    }
+
+    const options = params.options ?? {};
+    this.configuration.assertValidConfigAndRemoveEmptyKeys(options);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    options.baseURL ??= DEFAULT_BASE_URL;
+    const client = openai.createOpenAICompatible({
+      ...options,
+      name: 'zai',
+      baseURL: options.baseURL,
+    });
+    return client(params.model);
+  }
+}

--- a/src/lib/providers/configuration.ts
+++ b/src/lib/providers/configuration.ts
@@ -36,7 +36,11 @@ export interface ConfigAPI<ConfigObj extends object> {
     rec: Record<string, string> | undefined
   ): asserts rec is StringSlice<ConfigObj>;
   validateConfig(record: Record<string, string>): ConfigTypeValidationResult<ConfigObj>;
-  validateField(key: string, value: string | undefined): FieldValidationProblem | undefined;
+  validateField(
+    key: string,
+    value: string | undefined,
+    record?: Record<string, string>
+  ): FieldValidationProblem | undefined;
 }
 
 function formatMessage(
@@ -78,7 +82,11 @@ export function makeConfiguration<ConfigObj extends object>(
     );
     const fieldValidators: Map<
       string,
-      undefined | ((value: string | undefined) => FieldValidationProblem | undefined)
+      | undefined
+      | ((
+          value: string | undefined,
+          record?: Record<string, string>
+        ) => FieldValidationProblem | undefined)
     > = new Map(fields.map((field) => [String(field.key), field.validation]));
 
     // eslint-disable-next-line sonarjs/cognitive-complexity
@@ -101,7 +109,7 @@ export function makeConfiguration<ConfigObj extends object>(
       const fieldValidationWarnings: string[] = [];
       for (const [key, validator] of fieldValidators) {
         if (key in record && validator !== undefined) {
-          const validation = validator(record[key]);
+          const validation = validator(record[key], record);
           if (validation?.error !== undefined) {
             fieldValidationErrors.push(validation.error);
           }
@@ -134,9 +142,13 @@ export function makeConfiguration<ConfigObj extends object>(
       };
     }
 
-    function validateField(key: string, value: string): FieldValidationProblem | undefined {
+    function validateField(
+      key: string,
+      value: string,
+      record?: Record<string, string>
+    ): FieldValidationProblem | undefined {
       if (fieldValidators.has(key)) {
-        return fieldValidators.get(key)?.(value);
+        return fieldValidators.get(key)?.(value, record);
       }
       return undefined;
     }
@@ -191,7 +203,10 @@ export interface ConfigurationField<T extends object> {
   label: string;
   placeholder: string;
   required?: boolean;
-  validation?: (value: string | undefined) => FieldValidationProblem | undefined;
+  validation?: (
+    value: string | undefined,
+    record?: Record<string, string>
+  ) => FieldValidationProblem | undefined;
 }
 
 function hasAny<T extends object>(
@@ -237,11 +252,18 @@ export function apiKeyField<T extends { apiKey?: string }>(
     label: 'API Key',
     placeholder: typeof requirement === 'string' ? `${requirement}...` : '',
     required,
-    validation: (value: string | undefined) => {
+    validation: (value: string | undefined, record?: Record<string, string>) => {
       if (required && (value === undefined || value.trim().length === 0)) {
         return { error: 'API key is required' };
       }
-      if (typeof requirement === 'string' && value?.startsWith(requirement) === false) {
+      // Custom endpoints issue their own key formats, so only nudge about the
+      // vendor's typical prefix when talking to the default base URL
+      const hasCustomBaseUrl = (record?.['baseURL']?.trim().length ?? 0) > 0;
+      if (
+        typeof requirement === 'string' &&
+        value?.startsWith(requirement) === false &&
+        !hasCustomBaseUrl
+      ) {
         return { warning: `API key typically starts with "${requirement}"` };
       }
       if (typeof requirement === 'number' && (value?.length ?? 0) < requirement) {

--- a/src/lib/providers/index.ts
+++ b/src/lib/providers/index.ts
@@ -14,6 +14,8 @@ import { OllamaProvider } from './OllamaProvider';
 import { OpenAIProvider } from './OpenAIProvider';
 import { OpenRouterProvider } from './OpenRouterProvider';
 import { ProviderRegistry } from './ProviderRegistry';
+import { QwenProvider } from './QwenProvider';
+import { ZaiProvider } from './ZaiProvider';
 
 export type {
   AIProvider,
@@ -43,6 +45,8 @@ export const allProviders = {
   [createProviderId('mistral')]: MistralProvider,
   [createProviderId('moonshot')]: MoonshotProvider,
   [createProviderId('openrouter')]: OpenRouterProvider,
+  [createProviderId('qwen')]: QwenProvider,
+  [createProviderId('zai')]: ZaiProvider,
   [createProviderId('azure')]: AzureProvider,
 } satisfies Record<ProviderId, ProviderCtor>;
 

--- a/src/lib/providers/index.ts
+++ b/src/lib/providers/index.ts
@@ -3,6 +3,7 @@ import { getTelemetry } from '../telemetry';
 import { AnthropicProvider } from './AnthropicProvider';
 import { AzureProvider } from './AzureProvider';
 import { BedrockProvider } from './BedrockProvider';
+import { ClaudeCodeProvider } from './ClaudeCodeProvider';
 import { CohereProvider } from './CohereProvider';
 import { DeepseekProvider } from './DeepseekProvider';
 import { GoogleProvider } from './GoogleProvider';
@@ -32,6 +33,7 @@ export type {
 export const allProviders = {
   [createProviderId('openai')]: OpenAIProvider,
   [createProviderId('anthropic')]: AnthropicProvider,
+  [createProviderId('claude-code')]: ClaudeCodeProvider,
   [createProviderId('google')]: GoogleProvider,
   [createProviderId('bedrock')]: BedrockProvider,
   [createProviderId('cohere')]: CohereProvider,

--- a/tests/providers.claudeCode.test.ts
+++ b/tests/providers.claudeCode.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { createDefaultRegistry } from '../src/lib/providers';
+import { ClaudeCodeProvider } from '../src/lib/providers/ClaudeCodeProvider';
+import { createProviderId } from '../src/lib/types';
+
+describe('ClaudeCodeProvider', () => {
+  it('is valid with no configuration (auth handled by the CLI)', () => {
+    const provider = new ClaudeCodeProvider();
+    expect(provider.validateCredentials({}).isValid).toBe(true);
+    expect(provider.hasCredentials({})).toBe(true);
+  });
+
+  it('accepts optional cwd and executable path settings', () => {
+    const provider = new ClaudeCodeProvider();
+    const result = provider.validateCredentials({
+      cwd: '/some/project',
+      pathToClaudeCodeExecutable: '/usr/local/bin/claude',
+    });
+    expect(result.isValid).toBe(true);
+  });
+
+  it('provides builtin model aliases with a default', () => {
+    const provider = new ClaudeCodeProvider();
+    const ids = provider.models.map((model) => model.id as string);
+    expect(ids).toContain('sonnet');
+    expect(ids).toContain('opus');
+    expect(ids).toContain('haiku');
+    expect(provider.models.filter((model) => model.isDefault)).toHaveLength(1);
+  });
+
+  it('is registered in the default registry', () => {
+    const registry = createDefaultRegistry();
+    expect(registry.getProvider(createProviderId('claude-code'))).toBeInstanceOf(
+      ClaudeCodeProvider
+    );
+  });
+});

--- a/tests/providers.lmstudio.test.ts
+++ b/tests/providers.lmstudio.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LmStudioProvider } from '../src/lib/providers/LmStudioProvider';
+
+// Shaped like LM Studio's `/api/v0/models` response with JIT loading enabled:
+// every downloaded model is listed (loaded or not), including 'vlm' entries
+const JIT_MODEL_LIST = {
+  data: [
+    {
+      id: 'qwen2.5-7b-instruct',
+      object: 'model',
+      type: 'llm',
+      state: 'not-loaded',
+      max_context_length: 32_768,
+      capabilities: ['tool_use'],
+    },
+    {
+      id: 'qwen2-vl-7b-instruct',
+      object: 'model',
+      type: 'vlm',
+      state: 'not-loaded',
+      max_context_length: 32_768,
+      capabilities: ['vision'],
+    },
+    {
+      id: 'text-embedding-nomic-embed-text-v1.5',
+      object: 'model',
+      type: 'embeddings',
+      state: 'not-loaded',
+      max_context_length: 2048,
+    },
+  ],
+};
+
+function mockFetchWith(payload: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve(payload),
+    })
+  );
+}
+
+describe('LmStudioProvider.fetchModels', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('lists downloaded (not-loaded) models, including vlm entries', async () => {
+    mockFetchWith(JIT_MODEL_LIST);
+    const provider = new LmStudioProvider();
+    const models = await provider.fetchModels(undefined);
+
+    const ids = models.map((model) => model.id as string);
+    expect(ids).toContain('qwen2.5-7b-instruct');
+    expect(ids).toContain('qwen2-vl-7b-instruct');
+    // embeddings models are not chat models
+    expect(ids).not.toContain('text-embedding-nomic-embed-text-v1.5');
+
+    const vlm = models.find((model) => (model.id as string) === 'qwen2-vl-7b-instruct');
+    expect(vlm?.supportsVision).toBe(true);
+  });
+
+  it('skips malformed entries instead of failing the whole list', async () => {
+    mockFetchWith({
+      data: [
+        { id: 'good-model', type: 'llm' },
+        { type: 'llm' }, // missing id
+        'not-an-object',
+        { id: 'future-model', type: 'some-new-type' },
+      ],
+    });
+    const provider = new LmStudioProvider();
+    const models = await provider.fetchModels(undefined);
+    expect(models.map((model) => model.id as string)).toEqual(['good-model', 'future-model']);
+  });
+
+  it('still rejects a payload without a data array', async () => {
+    mockFetchWith({ error: 'nope' });
+    const provider = new LmStudioProvider();
+    await expect(provider.fetchModels(undefined)).rejects.toThrow(
+      'Unexpected LM Studio model list response payload'
+    );
+  });
+});

--- a/tests/providers.qwenZai.test.ts
+++ b/tests/providers.qwenZai.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { createDefaultRegistry } from '../src/lib/providers';
+import { QwenProvider } from '../src/lib/providers/QwenProvider';
+import { ZaiProvider } from '../src/lib/providers/ZaiProvider';
+import { createProviderId } from '../src/lib/types';
+
+describe('QwenProvider', () => {
+  it('requires an API key', () => {
+    const provider = new QwenProvider();
+    expect(provider.validateCredentials({}).isValid).toBe(false);
+    expect(provider.validateCredentials({ apiKey: 'sk-abc123' }).isValid).toBe(true);
+  });
+
+  it('offers Qwen 3 models with qwen3-max as default', () => {
+    const provider = new QwenProvider();
+    const ids = provider.models.map((model) => model.id as string);
+    expect(ids).toContain('qwen3-max');
+    expect(ids).toContain('qwen3-coder-plus');
+    const defaults = provider.models.filter((model) => model.isDefault);
+    expect(defaults).toHaveLength(1);
+    expect(defaults[0].id as string).toBe('qwen3-max');
+  });
+});
+
+describe('ZaiProvider', () => {
+  it('requires an API key', () => {
+    const provider = new ZaiProvider();
+    expect(provider.validateCredentials({}).isValid).toBe(false);
+    expect(provider.validateCredentials({ apiKey: 'a'.repeat(32) }).isValid).toBe(true);
+  });
+
+  it('offers GLM 4.6 as the default model', () => {
+    const provider = new ZaiProvider();
+    const defaults = provider.models.filter((model) => model.isDefault);
+    expect(defaults).toHaveLength(1);
+    expect(defaults[0].id as string).toBe('glm-4.6');
+  });
+});
+
+describe('default registry', () => {
+  it('includes Qwen and Z.ai providers', () => {
+    const registry = createDefaultRegistry();
+    expect(registry.getProvider(createProviderId('qwen'))).toBeInstanceOf(QwenProvider);
+    expect(registry.getProvider(createProviderId('zai'))).toBeInstanceOf(ZaiProvider);
+  });
+});

--- a/tests/providers.validation.test.ts
+++ b/tests/providers.validation.test.ts
@@ -13,4 +13,32 @@ describe('Provider configuration validation', () => {
     expect(provider.validateCredentials({ apiKey: 'sk-abc' }).isValid).toBe(true);
     expect(provider.validateCredentials({ baseURL: 'https://api.example.com' }).isValid).toBe(true);
   });
+
+  it('warns about key prefix only when using the default base URL', () => {
+    const provider = new OpenAIProvider();
+
+    const defaultEndpoint = provider.validateCredentials({ apiKey: 'my-custom-key' });
+    expect(defaultEndpoint.isValid).toBe(true);
+    expect(defaultEndpoint.warning).toContain('sk-');
+
+    // Custom endpoints (proxies, compatible gateways) issue their own key formats
+    const customEndpoint = provider.validateCredentials({
+      apiKey: 'my-custom-key',
+      baseURL: 'https://llm.example.com/v1',
+    });
+    expect(customEndpoint.isValid).toBe(true);
+    expect(customEndpoint.warning).toBeUndefined();
+  });
+
+  it('field-level validation also respects a custom base URL', () => {
+    const provider = new OpenAIProvider();
+    expect(provider.configuration.validateField('apiKey', 'my-custom-key')?.warning).toContain(
+      'sk-'
+    );
+    expect(
+      provider.configuration.validateField('apiKey', 'my-custom-key', {
+        baseURL: 'https://llm.example.com/v1',
+      })
+    ).toBeUndefined();
+  });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,6 +40,8 @@ export default defineConfig({
         '@ai-sdk/mistral',
         '@ai-sdk/cohere',
         'ai',
+        // Node-only provider: must stay a dynamic peer import, never bundled
+        'ai-sdk-provider-claude-code',
       ],
       output: {
         preserveModules: false,


### PR DESCRIPTION
## Summary
This PR adds three new AI model providers (Qwen, Z.ai, and Claude Code) to the model picker, along with improvements to configuration validation and LM Studio model discovery.

## Key Changes

### New Providers
- **QwenProvider**: Support for Alibaba Cloud's Qwen 3 and other DashScope models (qwen3-max, qwen3-coder-plus, qwen-plus, qwen-turbo)
- **ZaiProvider**: Support for Zhipu AI's GLM models (GLM 4.6, 4.5, 4.5 Air) via the Z.ai API
- **ClaudeCodeProvider**: Support for Claude models through the Claude Code CLI with subscription-based authentication (no API key required)

### Configuration & Validation Improvements
- Enhanced `validateField()` method to accept an optional `record` parameter, allowing field validators to access other form values for context-aware validation
- Updated API key validation to only warn about key prefix format when using the default base URL (custom endpoints/proxies may use different formats)
- Modified `AddModelForm` to pass form values to field validators for cross-field validation support

### LM Studio Provider Enhancements
- Improved model discovery to handle JIT-loaded models (both 'llm' and 'vlm' types)
- Made model type validation more flexible to support future model types beyond the currently documented set
- Changed model list parsing to skip malformed entries instead of rejecting the entire list
- Added proper handling for empty model IDs

### Icons
- Added QwenIcon (geometric pattern)
- Added ZaiIcon (stylized "Z" design)

### Testing
- Added comprehensive test suites for QwenProvider, ZaiProvider, and ClaudeCodeProvider
- Added tests for LM Studio model discovery with JIT loading
- Added validation tests for context-aware field validation with custom base URLs

### Documentation & Configuration
- Updated README to list new providers
- Updated package.json version to 0.5.0
- Added `ai-sdk-provider-claude-code` to Vite's external dependencies (dynamic peer import, never bundled)
- Exported new providers from main library index

## Notable Implementation Details
- All new providers use dynamic imports for their dependencies to avoid unnecessary bundling
- QwenProvider and ZaiProvider leverage the OpenAI-compatible SDK with custom base URLs
- ClaudeCodeProvider handles authentication through the Claude Code CLI rather than API keys
- Configuration validation now supports cross-field validation by passing the entire form record to validators

https://claude.ai/code/session_01HhfPeyDkq6rxAh87EC11HR

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/ai-sdk-react-model-picker/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

